### PR TITLE
[logstash] remove conditional config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,9 @@ services:
     environment:
       AWS_ACCESS_KEY_ID: aws_access_key_id
       AWS_SECRET_ACCESS_KEY: aws_secret_access_key
-      ENABLE_OUTPUT_ES: 1
-      ENABLE_OUTPUT_STDOUT: 1
       ES_HOST: elasticsearch
+      ES_PORT: "9200"
+      ES_PROTOCOL: http
       ES_REGION: us-east-1
       LOGSTASH_USER: logstash
       LOGSTASH_PASSWORD: logstash

--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -65,27 +65,11 @@ filter{
 }
 
 output {
-  if "${ENABLE_OUTPUT_AWS_ES:0}" == "1"  {
-    amazon_es {
-      hosts => ["${ES_HOST}"]
-      region => "${ES_REGION}"
-      index => "production-logs-%{+YYYY.MM.dd}"
-    }
-  }
-
-  # For local development
-  if "${ENABLE_OUTPUT_ES:0}" == "1"  {
-    elasticsearch {
-      hosts => ["${ES_HOST}"]
-      index => "production-logs-%{+YYYY.MM.dd}"
-    }
-  }
-
-
-  # Enable stdout as an output for development.
-  # Warning: If logstash is configured with the logstash log drain, it will
-  # create a feedback loop.
-  if "${ENABLE_OUTPUT_STDOUT:0}" == "1" {
-    stdout {}
+  amazon_es {
+    hosts => ["${ES_HOST}"]
+    port => "${ES_PORT:443}"
+    protocol => "${ES_PROTOCOL:https}"
+    region => "${ES_REGION}"
+    index => "production-logs-%{+YYYY.MM.dd}"
   }
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -21,8 +21,9 @@ applications:
       image: ghcr.io/gsa/datagov-logstash:7.4.2
     env:
       APP_NAME: ((app_name))
-      ENABLE_OUTPUT_AWS_ES: 1
       ES_REGION: us-gov-west-1
+      ES_PORT: "443"
+      ES_PROTOCOL: https
       _JAVA_OPTIONS: ((logstash_java_options))
     health-check-type: process
     instances: ((logstash_instances))

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -9,4 +9,4 @@ COPY Pipfile Pipfile.lock  /app/
 RUN pipenv install --dev
 
 ENTRYPOINT ["pipenv", "run"]
-CMD ["python", "-m", "unittest"]
+CMD ["pytest"]


### PR DESCRIPTION
The conditional configuration doesn't seem to be working in production. Use
a single config instead, but use some additional options for amazon_es to use
a vanilla elasticsearch. I haven't confirmed if logstash can actually push to
elasticsearch in development, but at least the tests are running.

Also, fix test discovery. Python unittest is not discovering tests, should be
using pytest anyway.
