### PR TITLE
Disable Kibana in cloud.gov

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -70,37 +70,3 @@ jobs:
         run: |
           sleep 20  # Logstash is very slow to start up
           [ "401" = "$(curl -w '%{http_code}' --output /dev/null --silent https://logstash-stage-datagov.app.cloud.gov)" ]
-
-  deploy-management:
-    if: github.ref == 'refs/heads/main'
-    name: deploy (management)
-    environment: management
-    runs-on: ubuntu-latest
-    needs:
-      - deploy-management-staging
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: deploy kibana proxy
-        uses: usds/cloud-gov-cli@master
-        with:
-          command: push logstack-kibana --vars-file vars.management.yml --strategy rolling
-          org: gsa-datagov
-          space: management
-          user: ${{secrets.CF_SERVICE_USER}}
-          password: ${{secrets.CF_SERVICE_AUTH}}
-      - name: smoke test kibana proxy
-        run: |
-          [ "401" = "$(curl -w '%{http_code}' --output /dev/null --silent https://logs-datagov.app.cloud.gov)" ]
-      - name: deploy logstash
-        uses: usds/cloud-gov-cli@master
-        with:
-          command: push logstack-logstash --vars-file vars.management.yml --strategy rolling
-          org: gsa-datagov
-          space: management
-          user: ${{secrets.CF_SERVICE_USER}}
-          password: ${{secrets.CF_SERVICE_AUTH}}
-      - name: smoke test logstash
-        run: |
-          sleep 20  # Logstash is very slow to start up
-          [ "401" = "$(curl -w '%{http_code}' --output /dev/null --silent https://logstash-prod-datagov.app.cloud.gov)" ]

--- a/vars.management-staging.yml
+++ b/vars.management-staging.yml
@@ -1,7 +1,7 @@
 ---
 app_name: logstack
 
-kibana_instances: 1
+kibana_instances: 0
 kibana_routes:
   - route: logs-stage-datagov.app.cloud.gov
 

--- a/vars.management.yml
+++ b/vars.management.yml
@@ -1,7 +1,7 @@
 ---
 app_name: logstack
 
-kibana_instances: 1
+kibana_instances: 0
 kibana_routes:
   - route: logs-datagov.app.cloud.gov
 


### PR DESCRIPTION
- Disable kibana instances in cloud.gov
- Freeze management

We're looking at other options for log handling. Disabling Kibana frees up precious memory quota.