### PR TITLE
Fix CF Github Action Environment.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,7 +123,7 @@ jobs:
           cf_username: ${{secrets.CF_SERVICE_USER}}
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
 
-  deploy-drain-prod:
+  drain-apps-in-prod:
     name: create drains (prod)
     environment: production
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,7 @@ jobs:
           sleep 20  # Logstash is very slow to start up
           [ "401" = "$(curl -w '%{http_code}' --output /dev/null --silent https://logstash-stage-datagov.app.cloud.gov)" ]
 
-  deploy-drain-staging:
+  drain-apps-in-staging:
     name: create drains (staging)
     environment: staging
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,7 +117,7 @@ jobs:
       - name: drain-staging-space
         uses: cloud-gov/cg-cli-tools@cli-v8
         with:
-          command: ./create-space-drain.sh
+          command: cf install-plugin -f -r CF-Community "drains" && ./create-space-drain.sh
           cf_org: gsa-datagov
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -133,7 +133,7 @@ jobs:
       - name: drain-prod-space
         uses: cloud-gov/cg-cli-tools@cli-v8
         with:
-          command: ./create-space-drain.sh
+          command: cf install-plugin -f -r CF-Community "drains" && ./create-space-drain.sh
           cf_org: gsa-datagov
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,6 +106,14 @@ jobs:
         run: |
           sleep 20  # Logstash is very slow to start up
           [ "401" = "$(curl -w '%{http_code}' --output /dev/null --silent https://logstash-stage-datagov.app.cloud.gov)" ]
+
+  deploy-drain-staging:
+    name: create drains (staging)
+    environment: staging
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-management
+    steps:
       - name: drain-staging-space
         uses: cloud-gov/cg-cli-tools@cli-v8
         with:
@@ -114,6 +122,14 @@ jobs:
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
+
+  deploy-drain-prod:
+    name: create drains (prod)
+    environment: production
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-management
+    steps:
       - name: drain-prod-space
         uses: cloud-gov/cg-cli-tools@cli-v8
         with:
@@ -122,4 +138,3 @@ jobs:
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,7 +124,7 @@ jobs:
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
 
   drain-apps-in-prod:
-    name: create drains (prod)
+    name: drain everything in prod space
     environment: production
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,7 +108,7 @@ jobs:
           [ "401" = "$(curl -w '%{http_code}' --output /dev/null --silent https://logstash-stage-datagov.app.cloud.gov)" ]
 
   drain-apps-in-staging:
-    name: create drains (staging)
+    name: drain everything in staging space
     environment: staging
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
I verified with similar actions in `catalog.data.gov` and `project-open-data-dashboard`.  CF Actions have only been run in separate "jobs" per space.  There's probably some global parameter that prevents it from context-switching.

Examples:
- catalog.data.gov
  - Staging: https://github.com/GSA/catalog.data.gov/blob/main/.github/workflows/publish.yml#L96
  - Prod: https://github.com/GSA/catalog.data.gov/blob/main/.github/workflows/publish.yml#L155
- project-open-data-dashboard
  - Staging: https://github.com/GSA/project-open-data-dashboard/blob/main/.github/workflows/restart.yml#L10
  - Prod: https://github.com/GSA/project-open-data-dashboard/blob/main/.github/workflows/restart.yml#L28
  
Feel free to have staging and prod be sequential if we want staging draining to be setup before prod draining.  I thought it didn't matter so I put it in parallel.