### PR TITLE
Use management credentials for draining prod and staging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
 
   drain-apps-in-staging:
     name: drain everything in staging space
-    environment: staging
+    environment: management
     runs-on: ubuntu-latest
     needs:
       - deploy-management
@@ -125,7 +125,7 @@ jobs:
 
   drain-apps-in-prod:
     name: drain everything in prod space
-    environment: production
+    environment: management
     runs-on: ubuntu-latest
     needs:
       - deploy-management


### PR DESCRIPTION
The deployer user has access to managment, prod, and staging. However, the GitHub Action needs to know which GitHub "environment" to grab the credentials for that user from. That's "management".