### PR TITLE
Github Action Fiasco

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,6 +116,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: apt-get install jq
       - name: drain-staging-space
         uses: cloud-gov/cg-cli-tools@cli-v8
         with:
@@ -134,6 +136,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: apt-get install jq
       - name: drain-prod-space
         uses: cloud-gov/cg-cli-tools@cli-v8
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,7 +117,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: Install Dependencies
-        run: apt-get install jq
+        run: sudo apt-get install -y jq
       - name: drain-staging-space
         uses: cloud-gov/cg-cli-tools@cli-v8
         with:
@@ -137,7 +137,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: Install Dependencies
-        run: apt-get install jq
+        run: sudo apt-get install -y jq
       - name: drain-prod-space
         uses: cloud-gov/cg-cli-tools@cli-v8
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,6 +114,8 @@ jobs:
     needs:
       - deploy-management
     steps:
+      - name: checkout
+        uses: actions/checkout@v2
       - name: drain-staging-space
         uses: cloud-gov/cg-cli-tools@cli-v8
         with:
@@ -130,6 +132,8 @@ jobs:
     needs:
       - deploy-management
     steps:
+      - name: checkout
+        uses: actions/checkout@v2
       - name: drain-prod-space
         uses: cloud-gov/cg-cli-tools@cli-v8
         with:


### PR DESCRIPTION
Checkout repo so that the action has access to needed files.

This [publish and deploy](https://github.com/GSA/datagov-logstack/actions/runs/1698216846) should be the one that works.