### PR TITLE
fix: /dev/urandom requires sudo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: create services
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: ./create-cloudgov-services.sh
+          command: sudo ./create-cloudgov-services.sh
           cf_org: gsa-datagov
           cf_space: management-staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -55,7 +55,7 @@ jobs:
       - name: create services
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: ./create-cloudgov-services.sh
+          command: sudo ./create-cloudgov-services.sh
           cf_org: gsa-datagov
           cf_space: management
           cf_username: ${{secrets.CF_SERVICE_USER}}


### PR DESCRIPTION
`./create-cloudgov-services.sh` failed because `logstash-secrets` did not exist in `management-staging` and `/dev/urandom` requires sudo.

Full Disclosure: there was no indication of this from the action failing.. https://github.com/GSA/datagov-logstack/runs/6215445099?check_suite_focus=true.  The only reason I know is because I tried to run it locally,

![image](https://user-images.githubusercontent.com/85196563/165855185-acc86707-f176-4e89-be2f-536c2f4aca45.png)
