### PR TITLE
Use openssl instead of /dev/urandom

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: create services
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: sudo ./create-cloudgov-services.sh
+          command: ./create-cloudgov-services.sh
           cf_org: gsa-datagov
           cf_space: management-staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -55,7 +55,7 @@ jobs:
       - name: create services
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: sudo ./create-cloudgov-services.sh
+          command: ./create-cloudgov-services.sh
           cf_org: gsa-datagov
           cf_space: management
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/create-cloudgov-services.sh
+++ b/create-cloudgov-services.sh
@@ -10,7 +10,7 @@ app_name=${1:-logstack}
 space=$(cf target | grep space | cut -d : -f 2 | xargs)
 
 # A function to generate a random quote-safe password
-randpw(){ < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo; }
+randpw(){ < openssl rand -base64 40 | tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo; }
 
 # Only create stuff in production and staging spaces
 if [ "$space" = "management" ] || [ "$space" = "management-staging" ]; then


### PR DESCRIPTION
Supersedes #31

Hopefully, openssl is installed in `cf-cli` Github Action container...

`openssl` does not require sudo, `/dev/urandom` does.