### PR TITLE
Takes more like 2 mins to become ready

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
       - name: smoke test logstash
         run: |
-          sleep 40  # Logstash is very slow to start up 
+          sleep 150  # Logstash is very slow to start up 
           [ "401" = "$(curl -w '%{http_code}' --output /dev/null --silent https://logstash-stage-datagov.app.cloud.gov)" ]
 
   create-cloudgov-services-management:
@@ -90,7 +90,7 @@ jobs:
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
       - name: smoke test
         run: |
-          sleep 40  # Logstash is very slow to start up
+          sleep 150  # Logstash is very slow to start up
           [ "401" = "$(curl -w '%{http_code}' --output /dev/null --silent https://logstash-stage-datagov.app.cloud.gov)" ]
 
   drain-apps-in-staging:


### PR DESCRIPTION
Inspecting the logs shows it takes a while :(

```
2022-04-29T11:45:51.20-0400 [APP/PROC/WEB/0] OUT Unpacking logstash...
   2022-04-29T11:45:59.41-0400 [APP/PROC/WEB/0] OUT Installing logstash plugins...
   2022-04-29T11:45:59.41-0400 [APP/PROC/WEB/0] OUT Using bundled JDK: /home/vcap/app/logstash-7.16.3/jdk
   2022-04-29T11:45:59.59-0400 [APP/PROC/WEB/0] ERR OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
   2022-04-29T11:46:05.43-0400 [APP/PROC/WEB/0] OUT Installing file: /home/vcap/app/plugins.zip
   2022-04-29T11:46:15.92-0400 [APP/PROC/WEB/0] OUT Resolving dependencies............................
   2022-04-29T11:46:16.23-0400 [APP/PROC/WEB/0] OUT Install successful
   2022-04-29T11:46:16.29-0400 [APP/PROC/WEB/0] OUT Installing Cloud Foundry root CA certificate...
   2022-04-29T11:46:16.29-0400 [APP/PROC/WEB/0] OUT Installing certificates: /etc/cf-system-certificates/*
   2022-04-29T11:46:16.59-0400 [APP/PROC/WEB/0] OUT keytool error: java.io.FileNotFoundException: /etc/cf-system-certificates/* (No such file or directory)
   2022-04-29T11:46:16.62-0400 [APP/PROC/WEB/0] OUT Using bundled JDK: /home/vcap/app/logstash-7.16.3/jdk
   2022-04-29T11:46:16.80-0400 [APP/PROC/WEB/0] ERR OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
   2022-04-29T11:46:33.37-0400 [APP/PROC/WEB/0] OUT Sending Logstash logs to /home/vcap/app/logstash-7.16.3/logs which is now configured via log4j2.properties
   2022-04-29T11:46:33.44-0400 [APP/PROC/WEB/0] OUT [2022-04-29T15:46:33,439][INFO ][logstash.runner          ] Log4j configuration path used is: /home/vcap/app/logstash-7.16.3/config/log4j2.properties
   2022-04-29T11:46:33.44-0400 [APP/PROC/WEB/0] OUT [2022-04-29T15:46:33,446][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"7.16.3", "jruby.version"=>"jruby 9.2.20.1 (2.5.8) 2021-11-30 2a2962fbd1 OpenJDK 64-Bit Server VM 11.0.13+8 on 11.0.13+8 +indy +jit [linux-x86_64]"}
   2022-04-29T11:46:33.47-0400 [APP/PROC/WEB/0] OUT [2022-04-29T15:46:33,472][INFO ][logstash.settings        ] Creating directory {:setting=>"path.queue", :path=>"/home/vcap/app/logstash-7.16.3/data/queue"}
   2022-04-29T11:46:33.48-0400 [APP/PROC/WEB/0] OUT [2022-04-29T15:46:33,481][INFO ][logstash.settings        ] Creating directory {:setting=>"path.dead_letter_queue", :path=>"/home/vcap/app/logstash-7.16.3/data/dead_letter_queue"}
   2022-04-29T11:46:33.76-0400 [APP/PROC/WEB/0] OUT [2022-04-29T15:46:33,764][WARN ][logstash.config.source.multilocal] Ignoring the 'pipelines.yml' file because modules or command line options are specified
   2022-04-29T11:46:33.78-0400 [APP/PROC/WEB/0] OUT [2022-04-29T15:46:33,781][INFO ][logstash.agent           ] No persistent UUID file found. Generating new UUID {:uuid=>"0b788fe5-42ba-453e-b574-ea99040e6757", :path=>"/home/vcap/app/logstash-7.16.3/data/uuid"}
   2022-04-29T11:46:34.39-0400 [APP/PROC/WEB/0] OUT [2022-04-29T15:46:34,391][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600, :ssl_enabled=>false}
   2022-04-29T11:46:35.42-0400 [APP/PROC/WEB/0] OUT [2022-04-29T15:46:35,421][INFO ][org.reflections.Reflections] Reflections took 64 ms to scan 1 urls, producing 119 keys and 417 values
   2022-04-29T11:46:40.96-0400 [RTR/3] OUT logstash-stage-datagov.app.cloud.gov - [2022-04-29T15:46:40.958380035Z] "GET / HTTP/1.1" 502 0 67 "-" 
```