### PR TITLE
Deploy semi-works again

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,8 +97,8 @@ jobs:
     name: drain everything in staging space
     environment: management
     runs-on: ubuntu-latest
-    # needs:
-    #   - deploy-management
+    needs:
+      - deploy-management
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -115,8 +115,8 @@ jobs:
     name: drain everything in prod space
     environment: management
     runs-on: ubuntu-latest
-    # needs:
-    #   - deploy-management
+    needs:
+      - deploy-management
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,7 @@ jobs:
       - name: drain-staging-space
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: sudo apt-get install -y jq && cf install-plugin -f -r CF-Community "drains" && ./create-space-drain.sh
+          command: apt-get install -y jq && cf install-plugin -f -r CF-Community "drains" && ./create-space-drain.sh
           cf_org: gsa-datagov
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -123,7 +123,7 @@ jobs:
       - name: drain-prod-space
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: sudo apt-get install -y jq && cf install-plugin -f -r CF-Community "drains" && ./create-space-drain.sh
+          command: apt-get install -y jq && cf install-plugin -f -r CF-Community "drains" && ./create-space-drain.sh
           cf_org: gsa-datagov
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,12 +102,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: Install Dependencies
-        run: sudo apt-get install -y jq
       - name: drain-staging-space
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: cf install-plugin -f -r CF-Community "drains" && ./create-space-drain.sh
+          command: sudo apt-get install -y jq && cf install-plugin -f -r CF-Community "drains" && ./create-space-drain.sh
           cf_org: gsa-datagov
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -122,12 +120,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: Install Dependencies
-        run: sudo apt-get install -y jq
       - name: drain-prod-space
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: cf install-plugin -f -r CF-Community "drains" && ./create-space-drain.sh
+          command: sudo apt-get install -y jq && cf install-plugin -f -r CF-Community "drains" && ./create-space-drain.sh
           cf_org: gsa-datagov
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,12 @@ jobs:
       - name: drain-staging-space
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: apt-get install -y jq && cf install-plugin -f -r CF-Community "drains" && ./create-space-drain.sh
+          command: |
+            apt-get install -y jq
+            cf install-plugin -f -r CF-Community "drains"
+            mkdir -p /root/.cf/
+            touch /root/.cf/config.json
+            ./create-space-drain.sh
           cf_org: gsa-datagov
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -123,7 +128,12 @@ jobs:
       - name: drain-prod-space
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: apt-get install -y jq && cf install-plugin -f -r CF-Community "drains" && ./create-space-drain.sh
+          command: |
+            apt-get install -y jq
+            cf install-plugin -f -r CF-Community "drains"
+            mkdir -p /root/.cf/
+            touch /root/.cf/config.json
+            ./create-space-drain.sh
           cf_org: gsa-datagov
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,11 +105,7 @@ jobs:
       - name: drain-staging-space
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: apt-get install -y jq && \
-            cf install-plugin -f -r CF-Community "drains" && \
-            mkdir -p /root/.cf/ && \
-            touch /root/.cf/config.json && \
-            ./create-space-drain.sh
+          command: apt-get install -y jq && cf install-plugin -f -r CF-Community "drains" && mkdir -p /root/.cf/ && touch /root/.cf/config.json && ./create-space-drain.sh
           cf_org: gsa-datagov
           cf_space: staging
           cf_username: ${{secrets.CF_SERVICE_USER}}
@@ -127,11 +123,7 @@ jobs:
       - name: drain-prod-space
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: apt-get install -y jq && \
-            cf install-plugin -f -r CF-Community "drains" && \
-            mkdir -p /root/.cf/ && \
-            touch /root/.cf/config.json && \
-            ./create-space-drain.sh
+          command: apt-get install -y jq && cf install-plugin -f -r CF-Community "drains" && mkdir -p /root/.cf/ && touch /root/.cf/config.json && ./create-space-drain.sh
           cf_org: gsa-datagov
           cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,19 +97,18 @@ jobs:
     name: drain everything in staging space
     environment: management
     runs-on: ubuntu-latest
-    needs:
-      - deploy-management
+    # needs:
+    #   - deploy-management
     steps:
       - name: checkout
         uses: actions/checkout@v2
       - name: drain-staging-space
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: |
-            apt-get install -y jq
-            cf install-plugin -f -r CF-Community "drains"
-            mkdir -p /root/.cf/
-            touch /root/.cf/config.json
+          command: apt-get install -y jq && \
+            cf install-plugin -f -r CF-Community "drains" && \
+            mkdir -p /root/.cf/ && \
+            touch /root/.cf/config.json && \
             ./create-space-drain.sh
           cf_org: gsa-datagov
           cf_space: staging
@@ -120,19 +119,18 @@ jobs:
     name: drain everything in prod space
     environment: management
     runs-on: ubuntu-latest
-    needs:
-      - deploy-management
+    # needs:
+    #   - deploy-management
     steps:
       - name: checkout
         uses: actions/checkout@v2
       - name: drain-prod-space
         uses: cloud-gov/cg-cli-tools@main
         with:
-          command: |
-            apt-get install -y jq
-            cf install-plugin -f -r CF-Community "drains"
-            mkdir -p /root/.cf/
-            touch /root/.cf/config.json
+          command: apt-get install -y jq && \
+            cf install-plugin -f -r CF-Community "drains" && \
+            mkdir -p /root/.cf/ && \
+            touch /root/.cf/config.json && \
             ./create-space-drain.sh
           cf_org: gsa-datagov
           cf_space: prod


### PR DESCRIPTION
The `drain everything in xxx space` doesn't exactly work on github actions.  However, the automated script works when run locally.  There are some weird dependencies and missing files in the github action that was created, it still throws errors though.

Successful Run: https://github.com/GSA/datagov-logstack/actions/runs/2248772195