### PR TITLE
fixed deploy and key issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   create-cloudgov-services-management-staging:
-    name: create services (management-staging)
+    name: create services (management-staging) 
     environment: management-staging
     runs-on: ubuntu-latest
     steps:
@@ -93,8 +93,46 @@ jobs:
           sleep 150  # Logstash is very slow to start up
           [ "401" = "$(curl -w '%{http_code}' --output /dev/null --silent https://logstash-stage-datagov.app.cloud.gov)" ]
 
+  drain-apps-in-management-staging:
+    name: drain apps in management-staging space
+    environment: management-staging
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-management-staging
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: drain-management-staging-space
+        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
+        with:
+          command: |
+            ./create-space-drain.sh management-staging
+          cf_org: gsa-datagov
+          cf_space: management-staging
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+
   drain-apps-in-staging:
-    name: drain everything in staging space
+    name: drain apps in staging space
+    environment: staging
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-management-staging
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: drain-staging-space
+        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
+        with:
+          command: |
+            ./create-space-drain.sh management-staging
+          cf_org: gsa-datagov
+          cf_space: staging
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+
+  drain-apps-in-management:
+    name: drain apps in management space
     environment: management
     runs-on: ubuntu-latest
     needs:
@@ -102,24 +140,19 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: drain-staging-space
-        uses: cloud-gov/cg-cli-tools@main
+      - name: drain-management-space
+        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
         with:
           command: |
-            apt-get install -y jq && 
-            curl -L -o drain-plugin  https://github.com/cloudfoundry/cf-drain-cli/releases/download/v2.0.0/cf-drain-cli-linux && 
-            cf install-plugin -f -r drain-plugin && 
-            rm -f drain-plugin && 
-            mkdir -p /root/.cf/ && touch /root/.cf/config.json && 
-            ./create-space-drain.sh management-staging
+            ./create-space-drain.sh management
           cf_org: gsa-datagov
-          cf_space: staging
+          cf_space: management
           cf_username: ${{secrets.CF_SERVICE_USER}}
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
 
   drain-apps-in-prod:
-    name: drain everything in prod space
-    environment: management
+    name: drain apps in prod space
+    environment: prod
     runs-on: ubuntu-latest
     needs:
       - deploy-management
@@ -127,16 +160,30 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: drain-prod-space
-        uses: cloud-gov/cg-cli-tools@main
+        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
         with:
           command: |
-            apt-get install -y jq && 
-            curl -L -o drain-plugin  https://github.com/cloudfoundry/cf-drain-cli/releases/download/v2.0.0/cf-drain-cli-linux && 
-            cf install-plugin -f -r drain-plugin &&
-            rm -f drain-plugin && 
-            mkdir -p /root/.cf/ && touch /root/.cf/config.json && 
             ./create-space-drain.sh management
           cf_org: gsa-datagov
           cf_space: prod
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+
+  drain-apps-in-prod-egress:
+    name: drain apps in prod-egress space
+    environment: prod-egress
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-management
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: drain-prod-egress-space
+        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
+        with:
+          command: |
+            ./create-space-drain.sh management
+          cf_org: gsa-datagov
+          cf_space: prod-egress
           cf_username: ${{secrets.CF_SERVICE_USER}}
           cf_password: ${{secrets.CF_SERVICE_AUTH}}

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -50,8 +50,8 @@ jobs:
           sleep 150  # Logstash is very slow to start up
           [ "401" = "$(curl -w '%{http_code}' --output /dev/null --silent https://logstash-development-datagov.app.cloud.gov)" ]
 
-  drain-apps-in-development:
-    name: drain everything in development space
+  drain-apps-in-development-ssb:
+    name: drain apps in development-ssb space
     environment: development-ssb
     runs-on: ubuntu-latest
     needs:
@@ -59,15 +59,29 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: drain-development-space
-        uses: cloud-gov/cg-cli-tools@main
+      - name: drain-development-ssb-space
+        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
         with:
           command: |
-            apt-get install -y jq && 
-            curl -L -o drain-plugin https://github.com/cloudfoundry/cf-drain-cli/releases/download/v2.0.0/cf-drain-cli-linux && 
-            cf install-plugin -f -r drain-plugin && 
-            rm -f drain-plugin && 
-            mkdir -p /root/.cf/ && touch /root/.cf/config.json && 
+            ./create-space-drain.sh development-ssb
+          cf_org: gsa-datagov
+          cf_space: development-ssb
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}   
+       
+  drain-apps-in-development:
+    name: drain apps in development space
+    environment: development
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-development-ssb
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: drain-development-space
+        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
+        with:
+          command: |
             ./create-space-drain.sh development-ssb
           cf_org: gsa-datagov
           cf_space: development

--- a/create-space-drain.sh
+++ b/create-space-drain.sh
@@ -18,8 +18,18 @@ prefix=${3:-logstack}
 # If the app already exists, exit early/successfully
 cf app "${prefix}-space-drain" > /dev/null 2>&1 && echo "Drain already exists." && exit 0
 
-# If the drain plugin isn't already installed, we can't proceed!
-cf drains --help > /dev/null 2>&1 || ( printf "cf_drain_cli plugin not found!\nInstall it with:\n    cf install-plugin -r CF-Community drains\n\n" && exit 1 )
+# install drain plugin if it isn't installed
+if ! cf plugins | grep -q drain; then
+    echo "cf-drain-cli plugin not found. Installing..."
+    apt install jq curl -y &&
+    curl -L -o drain-plugin https://github.com/cloudfoundry/cf-drain-cli/releases/download/v2.0.0/cf-drain-cli-linux --insecure &&
+    cf install-plugin -f  drain-plugin &&
+    rm -f drain-plugin &&
+    mkdir -p /root/.cf/ && touch /root/.cf/config.json && 
+    echo "cf-drain-cli plugin installed successfully."
+else
+    echo "cf-drain-cli plugin already exists."
+fi
 
 space=$(cf target | grep space: | cut -d : -f 2 | sed s/\ //g)
 
@@ -39,7 +49,7 @@ cat > manifest.yml << EOF
 ---
 applications:
 - name: ${prefix}-space-drain
-  instances: 0
+  instances: 1
   memory: 64M
   no-route: true
 EOF

--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -95,7 +95,7 @@ filter{
   if (
       ([log_data] and [log_data] =~ /^NginxLog/)
       or
-      ([hostname] and [http_status] and [hostname] =~ /^logstash-/ and [http_status] == "200")
+      ([hostname] and [status] and [hostname] =~ /^logstash-/ and [status] == "200")
   ) {
       drop { }
   }

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,8 +5,6 @@ applications:
     APP_NAME: ((app_name))
     LS_JAVA_OPTS: ((logstash_java_options))
     https_proxy: ((https_proxy))
-    NEWRELIC_LICENSE_KEY: ((logstash_newrelic_license_key))
-    NEWRELIC_LOG_URI: ((logstash_newrelic_log_uri))
   buildpacks:
     - binary_buildpack
   health-check-type: process

--- a/vars.development-ssb.yml
+++ b/vars.development-ssb.yml
@@ -16,5 +16,5 @@ https_proxy:
 
 # Optional license key for delivering logs to New Relic
 # See https://github.com/newrelic/logstash-output-plugin
-logstash_newrelic_license_key:
-logstash_newrelic_log_uri: https://gov-log-api.newrelic.com/log/v1
+# logstash_newrelic_license_key:
+# logstash_newrelic_log_uri: https://gov-log-api.newrelic.com/log/v1

--- a/vars.example.yml
+++ b/vars.example.yml
@@ -16,4 +16,4 @@ https_proxy:
 
 # Optional license key for delivering logs to New Relic
 # See https://github.com/newrelic/logstash-output-plugin
-logstash_newrelic_license_key: 
+# logstash_newrelic_license_key: 

--- a/vars.management-staging.yml
+++ b/vars.management-staging.yml
@@ -16,5 +16,5 @@ https_proxy:
 
 # Optional license key for delivering logs to New Relic
 # See https://github.com/newrelic/logstash-output-plugin
-logstash_newrelic_license_key: 
-logstash_newrelic_log_uri: https://gov-log-api.newrelic.com/log/v1
+# logstash_newrelic_license_key: 
+# logstash_newrelic_log_uri: https://gov-log-api.newrelic.com/log/v1

--- a/vars.management.yml
+++ b/vars.management.yml
@@ -16,5 +16,5 @@ https_proxy:
 
 # Optional license key for delivering logs to New Relic
 # See https://github.com/newrelic/logstash-output-plugin
-logstash_newrelic_license_key: 
-logstash_newrelic_log_uri: https://gov-log-api.newrelic.com/log/v1
+# logstash_newrelic_license_key: 
+# logstash_newrelic_log_uri: https://gov-log-api.newrelic.com/log/v1


### PR DESCRIPTION
- Resolved the deployment problem related to the cf-drain-cli plugin.
- Eliminated the unnecessary `New Relic license key` reset during deployment.
- Fixed field name typo `http_status` to `status`.
- Used an earlier version of `cloud-gov/cg-cli-tools` to ensure compatibility with the cf install-plugin functionality.
- Added additional spaces which draining app logs to New Relic via logstash.