### PR TITLE
Update cloudgov cli action tools

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -12,7 +12,7 @@ jobs:
       LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: test
         run: |
           chmod -R 777 logstash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: create services
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -32,7 +32,7 @@ jobs:
       - create-cloudgov-services-management-staging
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: build dependencies
         run: |
           chmod -R 777 logstash
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: create services
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -75,7 +75,7 @@ jobs:
       - deploy-management-staging
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: build dependencies
         run: |
           chmod -R 777 logstash
@@ -101,7 +101,7 @@ jobs:
       - deploy-management-staging
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: drain-management-staging-space
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -120,7 +120,7 @@ jobs:
       - deploy-management-staging
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: drain-staging-space
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -139,7 +139,7 @@ jobs:
       - deploy-management
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: drain-management-space
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -158,7 +158,7 @@ jobs:
       - deploy-management
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: drain-prod-space
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -177,7 +177,7 @@ jobs:
       - deploy-management
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: drain-prod-egress-space
         uses: cloud-gov/cg-cli-tools@main
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: drain-management-staging-space
-        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: |
             ./create-space-drain.sh management-staging
@@ -122,7 +122,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: drain-staging-space
-        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: |
             ./create-space-drain.sh management-staging
@@ -141,7 +141,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: drain-management-space
-        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: |
             ./create-space-drain.sh management
@@ -160,7 +160,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: drain-prod-space
-        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: |
             ./create-space-drain.sh management
@@ -179,7 +179,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: drain-prod-egress-space
-        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: |
             ./create-space-drain.sh management

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -60,7 +60,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: drain-development-ssb-space
-        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: |
             ./create-space-drain.sh development-ssb
@@ -79,7 +79,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: drain-development-space
-        uses: cloud-gov/cg-cli-tools@37d58fc10abf00a45926e8886879c81a498f7ea8
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: |
             ./create-space-drain.sh development-ssb

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: create services
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -32,7 +32,7 @@ jobs:
       - create-cloudgov-services-development-ssb
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: build dependencies
         run: |
           chmod -R 777 logstash
@@ -58,7 +58,7 @@ jobs:
       - deploy-development-ssb
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: drain-development-ssb-space
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -77,7 +77,7 @@ jobs:
       - deploy-development-ssb
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: drain-development-space
         uses: cloud-gov/cg-cli-tools@main
         with:

--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -85,19 +85,68 @@ filter{
   }
 
   ruby {
+    init => '
+      require "ipaddr"
+
+      @internal_ip_ranges = [
+        IPAddr.new("127.0.0.0/8"),      # IPv4 loopback
+        IPAddr.new("10.0.0.0/8"),       # RFC1918 private
+        IPAddr.new("172.16.0.0/12"),    # RFC1918 private
+        IPAddr.new("192.168.0.0/16"),   # RFC1918 private
+        IPAddr.new("169.254.0.0/16"),   # IPv4 link-local
+        IPAddr.new("100.64.0.0/10"),    # carrier-grade NAT / shared address space
+        IPAddr.new("0.0.0.0/8"),        # unspecified/current network
+
+        IPAddr.new("::1/128"),          # IPv6 loopback
+        IPAddr.new("fc00::/7"),         # IPv6 unique local
+        IPAddr.new("fe80::/10")         # IPv6 link-local
+      ]
+    '
+
     code => '
       xff = event.get("x_forwarded_for")
 
       if xff
-        ips = xff.split(",").map(&:strip).reject(&:empty?)
-        selected = ips[0]
+        ips = xff
+          .split(",")
+          .map { |ip| ip.strip }
+          .reject { |ip| ip.empty? || ip.downcase == "unknown" }
 
-        if selected =~ /\A127(?:\.\d{1,3}){3}\z/ || selected == "::1"
-          selected = ips[1] || selected
+        selected_ip = nil
+
+        ips.each do |raw_ip|
+          begin
+            parsed_ip = IPAddr.new(raw_ip)
+
+            is_internal = @internal_ip_ranges.any? do |range|
+              begin
+                range.include?(parsed_ip)
+              rescue
+                false
+              end
+            end
+
+            unless is_internal
+              selected_ip = raw_ip
+              break
+            end
+          rescue
+            next
+          end
         end
 
-        event.set("real_ip", selected) if selected
-        event.set("forwarded_ips", ips[1..-1].join(", ")) if ips.length > 1
+        # Fallback: if every IP is internal/invalid, keep the first usable value
+        selected_ip ||= ips.first
+
+        if selected_ip
+          event.set("real_ip", selected_ip)
+
+          selected_index = ips.index(selected_ip) || 0
+          remaining_ips = ips[(selected_index + 1)..-1] || []
+
+          event.set("forwarded_ips", remaining_ips.join(", ")) if remaining_ips.any?
+          event.set("xff_all_ips", ips)
+        end
       end
     '
   }


### PR DESCRIPTION
related to [5020](https://github.com/GSA/data.gov/issues/5020)

- draining apps [failed](https://github.com/GSA/datagov-logstack/actions/runs/28461251563) using pinned version of cg-cli-tools. deployment on dev space [worked](https://github.com/GSA/datagov-logstack/actions/runs/28469577579) using main branch instead.

testing this out on dev space i sent the following request 
```bash
MARK="xff-grok-test-$(date -u +%Y%m%dT%H%M%SZ)" # look for "xff-grok-test-20260630T195038Z"

curl -v \
  -u 'USERNAME:PASSWORD' \
  -H "User-Agent: ${MARK}" \
  -H 'X-Forwarded-For: 127.0.0.1, 203.0.113.42, 198.51.100.10' \
  -H 'Cache-Control: no-cache' \
  "https://catalog-dev.data.gov/?xff_test=${MARK}"
```

as you see in the picture `real_ip` is 203.0.113.42 despite putting loopback as the first forwarded ip address. forwarded ip addresses look like this in new relic

```203.0.113.42, 198.51.100.10, 2601:283:4404:9ee0:2cf9:daae:b3fc:9fab, 64.252.71.222, 127.0.0.1```

needed to update the private ip address handling code (wasn't working as intended)

<img width="1176" height="562" alt="Screenshot 2026-06-30 at 1 55 49 PM" src="https://github.com/user-attachments/assets/c6218965-7004-40a2-945e-2171db9e59e0" />
